### PR TITLE
feat: 백엔드 배포 트리거를 위한 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Trigger Backend Deployment
+
+on:
+  push:
+    branches:
+      - develop # 프론트엔드 develop 브랜치에 푸시될 때 실행
+  workflow_dispatch: # 수동으로 실행할 수 있도록 설정
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3 # 외부 Action 사용
+        with:
+          token: ${{ secrets.BACKEND_TRIGGER_PAT }} # 1단계에서 프론트엔드 레포에 저장한 PAT
+          repository: DEPthes/4th-MVP-LearningCrew-Server # <<<--- 백엔드 레포지토리 경로 입력!
+          event-type: frontend-update # <<<--- 백엔드 워크플로우 on.repository_dispatch.types 와 일치시켜야 함


### PR DESCRIPTION
- 프론트엔드 develop 브랜치에 푸시될 때 백엔드 배포를 트리거하는 워크플로우 생성
- 수동 실행을 위한 workflow_dispatch 설정 추가
- 외부 Action을 사용하여 Repository Dispatch 구현
- 백엔드 레포지토리 경로 및 이벤트 타입 설정

# 🌏Summary
- 백엔드 레포지토리의 자동 배포 설정을 프론트엔드에도 적용하기 위해 workflow를 생성하였습니다.

# ✔️ Task & Description
- [x] deploy.yml에 github actions workflow script 작성
